### PR TITLE
Filter deploy to master branch only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,16 +4,11 @@
 #
 version: 2
 jobs:
-  build:
+  build_test:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
       - image: circleci/python:3.7.5
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
 
     working_directory: ~/repo
 
@@ -33,12 +28,11 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r build_requirements.txt
-            pip install -r requirements.txt
 
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "build_requirements.txt" }}-{{ checksum "requirements.txt" }}
+          key: v1-dependencies-{{ checksum "build_requirements.txt" }}
 
       - run:
           name: run_tests
@@ -51,10 +45,33 @@ jobs:
           path: test-reports
           destination: test-reports
 
-      - run:
+  deploy_package:
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      - image: circleci/python:3.7.5
+
+    working_directory: ~/repo
+          - run:
           name: build_package
           command: |
             python3 setup.py sdist bdist_wheel
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "build_requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r build_requirements.txt
       - run:
           name: upload_package
           command: |
@@ -65,3 +82,14 @@ jobs:
             . venv/bin/activate
             ls -lrt dist/
             python3 -m twine upload --verbose --skip-existing dist/*
+workflows:
+  build_test_publish:
+    jobs:
+      - build_test
+      - deploy_package:
+          requires:
+            - build_test
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,16 +48,17 @@ jobs:
   deploy_package:
     docker:
       # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
       - image: circleci/python:3.7.5
 
     working_directory: ~/repo
-          - run:
-          name: build_package
-          command: |
-            python3 setup.py sdist bdist_wheel
+    
     steps:
       - checkout
+
+      - run:
+         name: build_package
+         command: |
+          python3 setup.py sdist bdist_wheel
 
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
-version: 2
+version: 2.1
 jobs:
   build_test:
     docker:


### PR DESCRIPTION
Update the circle ci config to ensure that the non master branches don't ship to pypi.